### PR TITLE
Download File Progress

### DIFF
--- a/HuggingfaceHub/HFDownloader.DownloadFile.cs
+++ b/HuggingfaceHub/HFDownloader.DownloadFile.cs
@@ -370,7 +370,7 @@ namespace HuggingfaceHub
                             {
                                 await fs.WriteAsync(buffer, 0, bytesRead);
                                 newResumeSize += bytesRead;
-                                progress?.Report((int)(newResumeSize * pieces / totalFileLengths));
+                                progress?.Report((int)Math.Floor(newResumeSize / totalFileLengths * 100));
                                 // Some data has been downloaded from the server so we reset the number of retries.
                                 retryLeft = 5;
                             }


### PR DESCRIPTION
The progress is reporting the number of downloaded pieces, which can be larger than 100. To download the progress in percentage (ranging from 0 to 100) devide size downloaded size by total file size and multiply by 100 (for percentage). Use Math.Floor to not report a progress of 100 when a byte is still missing.